### PR TITLE
Add unit and integration tests, fixtures

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest>=9.0.0
 pytest-asyncio>=0.24.0
+httpx>=0.27.0
+pytest-cov>=5.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.fixture
+def mock_cache():
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    return cache
+
+
+@pytest.fixture
+def sample_doc_id():
+    return "doc-test-001"

--- a/backend/tests/integration/test_ingestion.py
+++ b/backend/tests/integration/test_ingestion.py
@@ -1,0 +1,96 @@
+"""
+Doküman ingestion akışı entegrasyon testleri.
+Gerçek dosya I/O ve ML modelleri mock'lanmıştır.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+async def test_ingest_worker_cagrilabilir():
+    from app.workers.ingestion_worker import ingest_document
+
+    ctx = {"job_id": "job-001"}
+    # Worker henüz pipeline'a bağlı değil — None dönmeli
+    result = await ingest_document(ctx, "doc-abc", "/tmp/test.pdf")
+    assert result is None
+
+
+async def test_ingest_worker_parametreler_dogru_aliniyor():
+    from app.workers.ingestion_worker import ingest_document
+
+    ctx = {}
+    await ingest_document(ctx, document_id="doc-xyz", file_path="/path/file.docx")
+
+
+async def test_chunker_ve_embedder_zinciri():
+    from app.core.chunker import create_parent_child_chunks
+
+    metin = "Sözleşme maddeleri şu şekildedir. " * 60
+    meta = {
+        "doc_id": "ing-001",
+        "filename": "test.pdf",
+        "file_type": "pdf",
+        "language": "tr",
+        "session_id": "s",
+    }
+
+    parents, children = create_parent_child_chunks(metin, meta)
+
+    embedder = MagicMock()
+    embedder.encode.return_value = {
+        "dense": [[0.1] * 1024] * len(children),
+        "sparse": [{}] * len(children),
+    }
+
+    texts = [c["text"] for c in children]
+    vektorler = embedder.encode(texts)
+
+    assert len(vektorler["dense"]) == len(children)
+    assert len(vektorler["dense"][0]) == 1024
+
+
+async def test_ingest_pipeline_tam_akis():
+    from app.core.rag_pipeline import RAGPipeline
+
+    embedder = MagicMock()
+    embedder.encode.return_value = {
+        "dense": [[0.2] * 1024] * 3,
+        "sparse": [{} for _ in range(3)],
+    }
+
+    vs = MagicMock()
+    vs.store_parent_chunks = MagicMock()
+    vs.index_child_chunks = MagicMock()
+
+    reranker = MagicMock()
+    llm = MagicMock()
+    llm.generate = AsyncMock()
+
+    pipeline = RAGPipeline(
+        embedder=embedder,
+        vector_store=vs,
+        reranker=reranker,
+        llm_client=llm,
+        cache=None,
+    )
+
+    metin = "Madde 1: Taraflar sözleşmeyi kabul eder. " * 60
+    with patch.object(pipeline.processor, "process", return_value={
+        "doc_id": "doc-ing-001",
+        "filename": "sozlesme.pdf",
+        "file_type": "pdf",
+        "language": "tr",
+        "full_text": metin,
+        "pages": 1,
+    }):
+        result = await pipeline.ingest_document(
+            file_path="/tmp/sozlesme.pdf",
+            doc_id="doc-ing-001",
+            session_id="sess-ing",
+        )
+
+    assert result["doc_id"] == "doc-ing-001"
+    assert result["parent_count"] > 0
+    assert result["child_count"] > 0
+    vs.store_parent_chunks.assert_called_once()
+    vs.index_child_chunks.assert_called_once()

--- a/backend/tests/integration/test_rag_pipeline.py
+++ b/backend/tests/integration/test_rag_pipeline.py
@@ -1,0 +1,99 @@
+"""
+RAG pipeline uçtan uca entegrasyon testleri.
+Tüm dış bağımlılıklar (Qdrant, Redis, LLM, embedder) mock'lanmıştır.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from app.core.rag_pipeline import RAGPipeline
+
+
+def _pipeline_kur(llm_yanit="cevap metni"):
+    embedder = MagicMock()
+    embedder.encode_query.return_value = {
+        "dense": [[0.1] * 1024],
+        "sparse": [{}],
+    }
+
+    vs = MagicMock()
+    vs.hybrid_search.return_value = [
+        {
+            "text": "Sözleşme 30 gün bildirim gerektirir.",
+            "metadata": {
+                "doc_id": "d1",
+                "filename": "sozlesme.pdf",
+                "parent_chunk_id": "parent-d1-0001",
+            },
+        }
+    ]
+    vs.get_parent_by_id.return_value = {
+        "text": "Tam sözleşme metni burada. Fesih durumunda 30 gün önceden haber verilmesi gerekir.",
+        "metadata": {"doc_id": "d1", "filename": "sozlesme.pdf", "page_number": 2},
+    }
+    vs.get_parents_by_doc_id.return_value = []
+
+    reranker = MagicMock()
+    reranker.rerank.return_value = [
+        {
+            "text": "Sözleşme 30 gün bildirim gerektirir.",
+            "metadata": {
+                "doc_id": "d1",
+                "filename": "sozlesme.pdf",
+                "parent_chunk_id": "parent-d1-0001",
+            },
+            "score": 0.9,
+        }
+    ]
+
+    llm = MagicMock()
+    llm.generate = AsyncMock(return_value=llm_yanit)
+
+    return RAGPipeline(
+        embedder=embedder,
+        vector_store=vs,
+        reranker=reranker,
+        llm_client=llm,
+        cache=None,
+    )
+
+
+async def test_query_cevap_dondurur():
+    pipeline = _pipeline_kur("30 gün bildirim süresi geçerlidir.")
+    cevap, _ = await pipeline.query("Fesih süresi ne kadar?", "sess-test", ["d1"])
+    assert len(cevap) > 0
+
+
+async def test_query_kaynak_listesi_dolu():
+    pipeline = _pipeline_kur()
+    _, kaynaklar = await pipeline.query("Soru?", "sess-test", ["d1"])
+    assert isinstance(kaynaklar, list)
+    assert len(kaynaklar) > 0
+    assert "filename" in kaynaklar[0]
+    assert "doc_id" in kaynaklar[0]
+
+
+async def test_query_hic_chunk_bulunamaz():
+    pipeline = _pipeline_kur()
+    pipeline.vector_store.hybrid_search.return_value = []
+    pipeline.reranker.rerank.return_value = []
+    cevap, kaynaklar = await pipeline.query("Bilinmeyen soru?", "sess-test", [])
+    assert kaynaklar == []
+    assert len(cevap) > 0
+
+
+async def test_query_llm_bir_kez_cagrilir():
+    pipeline = _pipeline_kur("test cevabı")
+    await pipeline.query("Soru?", "sess-test", ["d1"])
+    pipeline.llm_client.generate.assert_awaited_once()
+
+
+async def test_query_cache_hit_llm_atlanir():
+    pipeline = _pipeline_kur()
+    pipeline.cache = AsyncMock()
+    pipeline.cache.get = AsyncMock(
+        return_value={"answer": "önbellekten", "sources": []}
+    )
+
+    cevap, kaynaklar = await pipeline.query("Önbellekli soru?", "sess-test")
+    assert cevap == "önbellekten"
+    pipeline.llm_client.generate.assert_not_awaited()

--- a/backend/tests/unit/test_api_chat.py
+++ b/backend/tests/unit/test_api_chat.py
@@ -1,0 +1,53 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes.chat import chat
+from app.services.chat_service import ChatRequest
+
+
+def _req(question="Belgedeki madde 5 nedir?", doc_ids=None):
+    return ChatRequest(
+        question=question,
+        session_id="sess-abc",
+        document_ids=doc_ids or [],
+    )
+
+
+def _http_req(cache=None):
+    r = MagicMock()
+    r.app.state.semantic_cache = cache
+    return r
+
+
+async def test_bos_soru_400_dondurur():
+    with pytest.raises(HTTPException) as exc:
+        await chat(_req(question="   "), _http_req())
+    assert exc.value.status_code == 400
+
+
+async def test_cache_yok_placeholder_doner():
+    result = await chat(_req(), _http_req(cache=None))
+    assert result.question == "Belgedeki madde 5 nedir?"
+    assert isinstance(result.sources, list)
+
+
+async def test_cache_hit_dogrudan_doner():
+    cached = {
+        "question": "önbellekli soru",
+        "answer": "önbellekten gelen cevap",
+        "sources": [],
+    }
+    mock_cache = AsyncMock()
+    mock_cache.get = AsyncMock(return_value=cached)
+
+    result = await chat(_req(question="önbellekli soru"), _http_req(cache=mock_cache))
+    assert result.answer == "önbellekten gelen cevap"
+    mock_cache.set.assert_not_called()
+
+
+async def test_cache_miss_kaydedilir(mock_cache):
+    result = await chat(_req(), _http_req(cache=mock_cache))
+    mock_cache.set.assert_called_once()
+    assert result is not None

--- a/backend/tests/unit/test_api_documents.py
+++ b/backend/tests/unit/test_api_documents.py
@@ -1,0 +1,20 @@
+from app.api.routes.documents import delete_document, list_documents
+
+
+async def test_liste_bos_donuyor():
+    result = await list_documents()
+    assert result["documents"] == []
+    assert result["total"] == 0
+
+
+async def test_silme_basarili_donus():
+    result = await delete_document("doc-xyz-123")
+    assert result.document_id == "doc-xyz-123"
+    assert result.deleted is True
+
+
+async def test_silme_farkli_id():
+    r1 = await delete_document("id-aaa")
+    r2 = await delete_document("id-bbb")
+    assert r1.document_id == "id-aaa"
+    assert r2.document_id == "id-bbb"

--- a/backend/tests/unit/test_api_upload.py
+++ b/backend/tests/unit/test_api_upload.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes.upload import upload_documents, validate_file
+
+
+def _dosya(ad="sozlesme.pdf", icerik=b"%PDF-1.4 test"):
+    f = MagicMock()
+    f.filename = ad
+    f.read = AsyncMock(return_value=icerik)
+    return f
+
+
+def _aiofiles_mock():
+    dosya_mock = AsyncMock()
+    dosya_mock.write = AsyncMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=dosya_mock)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def test_gecersiz_uzanti_reddedilir():
+    with pytest.raises(HTTPException) as exc:
+        validate_file(_dosya("kotu.exe"))
+    assert exc.value.status_code == 400
+
+
+def test_pdf_uzantisi_kabul_edilir():
+    ext = validate_file(_dosya("test.pdf"))
+    assert ext == "pdf"
+
+
+def test_txt_uzantisi_kabul_edilir():
+    ext = validate_file(_dosya("aciklama.txt"))
+    assert ext == "txt"
+
+
+def test_docx_uzantisi_kabul_edilir():
+    ext = validate_file(_dosya("rapor.docx"))
+    assert ext == "docx"
+
+
+async def test_pdf_yukleme_queued_doner():
+    with patch("aiofiles.open", return_value=_aiofiles_mock()):
+        result = await upload_documents(files=[_dosya()], session_id="sess-001")
+    assert len(result) == 1
+    assert result[0].status == "queued"
+    assert result[0].filename == "sozlesme.pdf"
+
+
+async def test_coklu_dosya_yukleme():
+    dosyalar = [_dosya("a.pdf"), _dosya("b.docx"), _dosya("c.txt")]
+    with patch("aiofiles.open", return_value=_aiofiles_mock()):
+        result = await upload_documents(files=dosyalar, session_id="sess-002")
+    assert len(result) == 3
+
+
+async def test_her_dosyaya_benzersiz_id_atanir():
+    dosyalar = [_dosya("x.pdf"), _dosya("y.pdf")]
+    with patch("aiofiles.open", return_value=_aiofiles_mock()):
+        result = await upload_documents(files=dosyalar, session_id="s")
+    assert result[0].document_id != result[1].document_id
+
+
+async def test_gecersiz_uzanti_http_exception_firlatir():
+    with pytest.raises(HTTPException):
+        await upload_documents(files=[_dosya("virus.sh")], session_id="s")

--- a/backend/tests/unit/test_health.py
+++ b/backend/tests/unit/test_health.py
@@ -1,13 +1,141 @@
-from app.api.routes.health import health_check
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.api.routes import health as health_module
+from app.models.health import ServiceStatus
 
 
-async def test_health_status_ok():
-    result = await health_check()
-    assert result["status"] == "ok"
+# ── _check_redis ──────────────────────────────────────────────────────────────
+
+async def test_check_redis_ok():
+    mock_client = AsyncMock()
+    mock_client.ping = AsyncMock(return_value=True)
+    mock_client.aclose = AsyncMock()
+
+    with patch("app.api.routes.health.aioredis.from_url", return_value=mock_client):
+        result = await health_module._check_redis()
+
+    assert result.status == "ok"
+    assert result.latency_ms is not None
+    assert result.latency_ms >= 0
+    assert result.detail is None
 
 
-async def test_health_has_app_and_version():
-    result = await health_check()
-    assert "app" in result
-    assert "version" in result
-    assert result["app"] is not None
+async def test_check_redis_connection_error():
+    mock_client = AsyncMock()
+    mock_client.ping = AsyncMock(side_effect=ConnectionError("connection refused"))
+    mock_client.aclose = AsyncMock()
+
+    with patch("app.api.routes.health.aioredis.from_url", return_value=mock_client):
+        result = await health_module._check_redis()
+
+    assert result.status == "unreachable"
+    assert result.latency_ms is None
+    assert "connection refused" in result.detail
+
+
+async def test_check_redis_timeout():
+    mock_client = AsyncMock()
+    mock_client.ping = AsyncMock(side_effect=asyncio.TimeoutError())
+    mock_client.aclose = AsyncMock()
+
+    with patch("app.api.routes.health.aioredis.from_url", return_value=mock_client):
+        result = await health_module._check_redis()
+
+    assert result.status == "unreachable"
+    assert result.latency_ms is None
+
+
+# ── _check_qdrant ─────────────────────────────────────────────────────────────
+
+async def test_check_qdrant_ok():
+    mock_client = AsyncMock()
+    mock_client.get_collections = AsyncMock(return_value=MagicMock())
+    mock_client.close = AsyncMock()
+
+    with patch("app.api.routes.health.AsyncQdrantClient", return_value=mock_client):
+        result = await health_module._check_qdrant()
+
+    assert result.status == "ok"
+    assert result.latency_ms >= 0
+    assert result.detail is None
+
+
+async def test_check_qdrant_error():
+    mock_client = AsyncMock()
+    mock_client.get_collections = AsyncMock(side_effect=Exception("connection refused"))
+    mock_client.close = AsyncMock()
+
+    with patch("app.api.routes.health.AsyncQdrantClient", return_value=mock_client):
+        result = await health_module._check_qdrant()
+
+    assert result.status == "unreachable"
+    assert result.detail is not None
+
+
+# ── /live ─────────────────────────────────────────────────────────────────────
+
+async def test_liveness_always_ok():
+    result = await health_module.liveness()
+    assert result == {"status": "ok"}
+
+
+# ── /ready ────────────────────────────────────────────────────────────────────
+
+async def test_readiness_200_when_all_ok():
+    ok = ServiceStatus(status="ok", latency_ms=1.5)
+
+    with patch.object(health_module, "_check_redis", AsyncMock(return_value=ok)), \
+         patch.object(health_module, "_check_qdrant", AsyncMock(return_value=ok)):
+        response = await health_module.readiness()
+
+    assert response.status_code == 200
+
+
+async def test_readiness_503_when_redis_down():
+    ok = ServiceStatus(status="ok", latency_ms=1.5)
+    down = ServiceStatus(status="unreachable", detail="refused")
+
+    with patch.object(health_module, "_check_redis", AsyncMock(return_value=down)), \
+         patch.object(health_module, "_check_qdrant", AsyncMock(return_value=ok)):
+        response = await health_module.readiness()
+
+    assert response.status_code == 503
+
+
+async def test_readiness_503_when_qdrant_down():
+    ok = ServiceStatus(status="ok", latency_ms=2.0)
+    down = ServiceStatus(status="unreachable", detail="timeout")
+
+    with patch.object(health_module, "_check_redis", AsyncMock(return_value=ok)), \
+         patch.object(health_module, "_check_qdrant", AsyncMock(return_value=down)):
+        response = await health_module.readiness()
+
+    assert response.status_code == 503
+
+
+# ── /detailed ─────────────────────────────────────────────────────────────────
+
+async def test_detailed_always_200_even_when_degraded():
+    ok = ServiceStatus(status="ok", latency_ms=1.0)
+    down = ServiceStatus(status="unreachable", detail="timeout")
+
+    with patch.object(health_module, "_check_redis", AsyncMock(return_value=down)), \
+         patch.object(health_module, "_check_qdrant", AsyncMock(return_value=ok)):
+        result = await health_module.health_detailed()
+
+    assert result.status == "degraded"
+    assert result.services["redis"].status == "unreachable"
+    assert result.services["qdrant"].status == "ok"
+
+
+async def test_detailed_ok_when_all_services_up():
+    ok = ServiceStatus(status="ok", latency_ms=1.0)
+
+    with patch.object(health_module, "_check_redis", AsyncMock(return_value=ok)), \
+         patch.object(health_module, "_check_qdrant", AsyncMock(return_value=ok)):
+        result = await health_module.health_detailed()
+
+    assert result.status == "ok"
+    assert result.app is not None
+    assert result.version is not None

--- a/backend/tests/unit/test_health.py
+++ b/backend/tests/unit/test_health.py
@@ -1,0 +1,13 @@
+from app.api.routes.health import health_check
+
+
+async def test_health_status_ok():
+    result = await health_check()
+    assert result["status"] == "ok"
+
+
+async def test_health_has_app_and_version():
+    result = await health_check()
+    assert "app" in result
+    assert "version" in result
+    assert result["app"] is not None


### PR DESCRIPTION
Add comprehensive test coverage: new unit tests for chat, documents, upload, and health endpoints, and integration tests for ingestion and the RAG pipeline. Introduce pytest fixtures in backend/tests/conftest.py (mock_cache, sample_doc_id) and extensive use of mocks for external dependencies (LLM, embedder, vector store, file I/O). Update backend/requirements-dev.txt to include httpx and pytest-cov to support async HTTP testing and coverage reporting. These changes improve testability and CI readiness by exercising core flows and edge cases without relying on real external services.