### PR TITLE
feat: wire up SSE streaming, async ingestion worker, and live RAG pip…

### DIFF
--- a/backend/app/api/routes/chat.py
+++ b/backend/app/api/routes/chat.py
@@ -1,9 +1,8 @@
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
-import asyncio
 import json
 
-from app.services.chat_service import ChatRequest, ChatResponse
+from app.services.chat_service import ChatRequest, ChatResponse, SourceInfo
 
 router = APIRouter()
 
@@ -13,25 +12,30 @@ async def chat(request: ChatRequest, req: Request):
     if not request.question.strip():
         raise HTTPException(status_code=400, detail="Soru boş olamaz.")
 
-    sc = getattr(req.app.state, "semantic_cache", None)
-    if sc is not None:
-        cached = await sc.get(request.question)
-        if cached is not None:
-            return ChatResponse(**cached)
+    pipeline = getattr(req.app.state, "rag_pipeline", None)
+    if pipeline is None:
+        return ChatResponse(
+            question=request.question,
+            answer="RAG pipeline hazır değil.",
+            sources=[],
+        )
 
-    # rag akisi baglanacak
-    # response = await rag_service.query(request.question, request.document_ids)
-
-    response = ChatResponse(
-        question=request.question,
-        answer="ML pipeline henüz bağlanmadı.",
-        sources=[],
+    answer, raw_sources = await pipeline.query(
+        request.question,
+        request.session_id,
+        request.document_ids,
     )
 
-    if sc is not None:
-        await sc.set(request.question, response.model_dump())
+    sources = [
+        SourceInfo(
+            document_id=s.get("doc_id", ""),
+            filename=s.get("filename", ""),
+            chunk_text="",
+        )
+        for s in raw_sources
+    ]
 
-    return response
+    return ChatResponse(question=request.question, answer=answer, sources=sources)
 
 
 @router.post("/stream")
@@ -39,40 +43,28 @@ async def chat_stream(request: ChatRequest, req: Request):
     if not request.question.strip():
         raise HTTPException(status_code=400, detail="Soru boş olamaz.")
 
-    sc = getattr(req.app.state, "semantic_cache", None)
-    cached_answer = None
-    if sc is not None:
-        cached = await sc.get(request.question)
-        if cached is not None:
-            cached_answer = cached.get("answer", "")
+    pipeline = getattr(req.app.state, "rag_pipeline", None)
 
     async def event_generator():
-        if cached_answer is not None:
-            words = cached_answer.split(" ")
-            for word in words:
-                yield f"data: {json.dumps({'type': 'token', 'content': word + ' '})}\n\n"
-                await asyncio.sleep(0.02)
-            yield f"data: {json.dumps({'type': 'done'})}\n\n"
+        if pipeline is None:
+            yield f"data: {json.dumps({'type': 'error', 'message': 'RAG pipeline hazır değil.'})}\n\n"
             return
 
-        # streaming rag buraya baglanacak
-        # async for chunk in rag_service.stream(request.question):
-        #     yield f"data: {json.dumps({'type': 'token', 'content': chunk})}\n\n"
+        try:
+            async for item in pipeline.query_stream(
+                request.question,
+                request.session_id,
+                request.document_ids,
+            ):
+                if isinstance(item, dict) and "__sources__" in item:
+                    yield f"data: {json.dumps({'type': 'sources', 'documents': item['__sources__']})}\n\n"
+                else:
+                    yield f"data: {json.dumps({'type': 'token', 'content': item})}\n\n"
 
-        words = ["ML", " pipeline", " henüz", " bağlanmadı."]
-        full_answer = "".join(words)
-        for word in words:
-            yield f"data: {json.dumps({'type': 'token', 'content': word})}\n\n"
-            await asyncio.sleep(0.05)
-        yield f"data: {json.dumps({'type': 'done'})}\n\n"
+            yield f"data: {json.dumps({'type': 'done'})}\n\n"
 
-        if sc is not None:
-            response_data = ChatResponse(
-                question=request.question,
-                answer=full_answer,
-                sources=[],
-            ).model_dump()
-            await sc.set(request.question, response_data)
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
 
     return StreamingResponse(
         event_generator(),
@@ -81,5 +73,5 @@ async def chat_stream(request: ChatRequest, req: Request):
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
-        }
+        },
     )

--- a/backend/app/api/routes/documents.py
+++ b/backend/app/api/routes/documents.py
@@ -1,17 +1,59 @@
-from fastapi import APIRouter, HTTPException
+from datetime import datetime, timezone
+from typing import List
 
-from app.services.document_service import DocumentDeleteResponse
+from fastapi import APIRouter, HTTPException, Request
+
+from app.services.document_service import DocumentDeleteResponse, DocumentListItem
 
 router = APIRouter()
 
 
+def _get_vector_store():
+    from app.core.vector_store import VectorStore
+    from app.config import get_settings
+    settings = get_settings()
+    vs = VectorStore(host=settings.QDRANT_HOST, port=settings.QDRANT_PORT)
+    vs.setup()
+    return vs
+
+
 @router.get("")
-async def list_documents():
-    # qdrant baglaninca dolacak burasi
-    return {"documents": [], "total": 0}
+async def list_documents(request: Request, session_id: str = "default"):
+    rag_pipeline = getattr(request.app.state, "rag_pipeline", None)
+    if rag_pipeline is not None:
+        vs = rag_pipeline.vector_store
+    else:
+        vs = _get_vector_store()
+
+    try:
+        docs = vs.list_documents(session_id=session_id)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Doküman listesi alınamadı: {exc}")
+
+    items: List[DocumentListItem] = [
+        DocumentListItem(
+            document_id=d["doc_id"],
+            filename=d["filename"],
+            created_at=datetime.now(timezone.utc),
+            chunk_count=d.get("chunk_count"),
+            status="completed",
+        )
+        for d in docs
+    ]
+    return {"documents": items, "total": len(items)}
 
 
 @router.delete("/{document_id}", response_model=DocumentDeleteResponse)
-async def delete_document(document_id: str):
-    # qdrant baglaninca dolacak burasi
+async def delete_document(document_id: str, request: Request, session_id: str = "default"):
+    rag_pipeline = getattr(request.app.state, "rag_pipeline", None)
+    if rag_pipeline is not None:
+        vs = rag_pipeline.vector_store
+    else:
+        vs = _get_vector_store()
+
+    try:
+        vs.delete_document(doc_id=document_id, session_id=session_id)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Doküman silinemedi: {exc}")
+
     return DocumentDeleteResponse(document_id=document_id, deleted=True)

--- a/backend/app/api/routes/tasks.py
+++ b/backend/app/api/routes/tasks.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from arq.jobs import Job, JobStatus
+
+from app.models.task import TaskResponse, TaskStatus
+
+router = APIRouter()
+
+_ARQ_TO_TASK_STATUS = {
+    JobStatus.queued: TaskStatus.pending,
+    JobStatus.in_progress: TaskStatus.running,
+    JobStatus.complete: TaskStatus.completed,
+    JobStatus.not_found: TaskStatus.not_found,
+    JobStatus.deferred: TaskStatus.pending,
+}
+
+
+@router.get("/{job_id}", response_model=TaskResponse)
+async def get_task_status(job_id: str, request: Request):
+    arq_redis = getattr(request.app.state, "arq_redis", None)
+    if arq_redis is None:
+        raise HTTPException(status_code=503, detail="Task queue unavailable")
+
+    job = Job(job_id, redis=arq_redis)
+    arq_status = await job.status()
+
+    if arq_status == JobStatus.not_found:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    task_status = _ARQ_TO_TASK_STATUS.get(arq_status, TaskStatus.pending)
+    result = None
+    error = None
+    created_at = None
+
+    info = await job.info()
+    if info:
+        created_at = info.enqueue_time
+
+    if arq_status == JobStatus.complete:
+        try:
+            result = await job.result(timeout=0)
+        except Exception as exc:
+            task_status = TaskStatus.failed
+            error = str(exc)
+
+    return TaskResponse(
+        job_id=job_id,
+        status=task_status,
+        created_at=created_at,
+        result=result,
+        error=error,
+    )
+
+
+@router.get("/{job_id}/progress")
+async def get_task_progress(job_id: str, request: Request):
+    arq_redis = getattr(request.app.state, "arq_redis", None)
+    if arq_redis is None:
+        raise HTTPException(status_code=503, detail="Task queue unavailable")
+
+    async def event_stream():
+        while True:
+            raw = await arq_redis.get(f"progress:{job_id}")
+            if raw:
+                data = json.loads(raw)
+                event_type = data.get("event", "progress")
+
+                if event_type == "done":
+                    yield f"event: done\ndata: {json.dumps({'status': 'completed'})}\n\n"
+                    return
+                elif event_type == "error":
+                    yield f"event: error\ndata: {json.dumps({'message': data.get('message', '')})}\n\n"
+                    return
+                else:
+                    stage = data.get("stage", "")
+                    pct = data.get("pct", 0)
+                    yield f"event: progress\ndata: {json.dumps({'stage': stage, 'pct': pct})}\n\n"
+
+            job = Job(job_id, redis=arq_redis)
+            arq_status = await job.status()
+            if arq_status == JobStatus.complete:
+                yield f"event: done\ndata: {json.dumps({'status': 'completed'})}\n\n"
+                return
+            if arq_status == JobStatus.not_found:
+                yield f"event: error\ndata: {json.dumps({'message': 'Job not found'})}\n\n"
+                return
+
+            await asyncio.sleep(1)
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")

--- a/backend/app/api/routes/upload.py
+++ b/backend/app/api/routes/upload.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException , UploadFile, File
+from fastapi import APIRouter, HTTPException, UploadFile, File, Request
 from typing import List
 import uuid
 import os
@@ -24,8 +24,12 @@ def validate_file(file: UploadFile):
 
 
 @router.post("", response_model=List[DocumentUploadResponse])
-async def upload_documents( files: List[UploadFile] = File(...),
-    session_id: str = "default"):
+async def upload_documents(
+    request: Request,
+    files: List[UploadFile] = File(...),
+    session_id: str = "default",
+):
+    arq_redis = request.app.state.arq_redis
     responses = []
 
     for file in files:
@@ -40,10 +44,10 @@ async def upload_documents( files: List[UploadFile] = File(...),
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Dosya kaydedilemedi: {str(e)}")
 
-        # pipeline buraya bağlanacak
-        # await rag_pipeline.process(document_id, save_path)
+        job = await arq_redis.enqueue_job("ingest_document", document_id, save_path)
 
         responses.append(DocumentUploadResponse(
+            job_id=job.job_id,
             document_id=document_id,
             filename=file.filename,
             status="queued",

--- a/backend/app/core/rag_pipeline.py
+++ b/backend/app/core/rag_pipeline.py
@@ -270,7 +270,7 @@ class RAGPipeline:
         question: str,
         session_id: str,
         doc_ids: list[str] | None = None,
-    ) -> AsyncGenerator[str]:
+    ) -> AsyncGenerator[str | dict]:
         """
         Streaming soru-cevap pipeline'ı.
 
@@ -299,6 +299,7 @@ class RAGPipeline:
                     trace.update(tags=["cache-hit"])
                     trace.end(output=cached["answer"])
                 yield cached["answer"]
+                yield {"__sources__": cached.get("sources", [])}
                 return
 
         # Retrieval + parent resolution
@@ -309,6 +310,7 @@ class RAGPipeline:
             if trace:
                 trace.end(output=ans)
             yield ans
+            yield {"__sources__": []}
             return
 
         prompt = build_rag_prompt(question, context_chunks)
@@ -330,8 +332,9 @@ class RAGPipeline:
         if generation:
             generation.end(output=full_answer)
 
-        # Stream bittikten sonra cache'e kaydet
+        # Stream bittikten sonra kaynakları yield et, ardından cache'e kaydet
         sources = self._extract_sources(context_chunks)
+        yield {"__sources__": sources}
         if self.cache:
             await self.cache.set(
                 question,

--- a/backend/app/core/vector_store.py
+++ b/backend/app/core/vector_store.py
@@ -354,6 +354,49 @@ class VectorStore:
             )
         return parents
 
+    def list_documents(self, session_id: str) -> list[dict]:
+        """
+        Bir session'a ait tüm unique dokümanları döndürür.
+
+        Parent koleksiyonunu scroll ederek benzersiz doc_id + filename
+        çiftlerini toplar. Büyük koleksiyonlar için offset-based scroll
+        kullanılır.
+
+        Returns:
+            list[dict]: [{"doc_id": str, "filename": str, "chunk_count": int}, ...]
+        """
+        seen: dict[str, dict] = {}
+        offset = None
+
+        while True:
+            points, next_offset = self.client.scroll(
+                collection_name=self.PARENT_COLLECTION,
+                scroll_filter=Filter(
+                    must=[FieldCondition(key="session_id", match=MatchValue(value=session_id))]
+                ),
+                limit=200,
+                offset=offset,
+                with_payload=True,
+            )
+
+            for point in points:
+                doc_id = point.payload.get("doc_id")
+                if not doc_id:
+                    continue
+                if doc_id not in seen:
+                    seen[doc_id] = {
+                        "doc_id": doc_id,
+                        "filename": point.payload.get("filename", ""),
+                        "chunk_count": 0,
+                    }
+                seen[doc_id]["chunk_count"] += 1
+
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        return list(seen.values())
+
     def delete_document(self, doc_id: str, session_id: str):
         """
         Bir dokümanın tüm chunk'larını siler (child + parent).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,17 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import os
 
+import logging
+
+from arq.connections import create_pool, RedisSettings
+
 from app.config import get_settings
-from app.api.routes import documents, chat, summarize, health, upload
+from app.api.routes import documents, chat, summarize, health, upload, tasks
+from app.core.embedder import get_embedder
+from app.core.llm_client import create_llm_client
+from app.core.rag_pipeline import RAGPipeline
+from app.core.reranker import Reranker
+from app.core.vector_store import VectorStore
 
 settings = get_settings()
 
@@ -14,6 +23,15 @@ async def lifespan(app: FastAPI):
     os.environ.setdefault("HF_HOME", settings.HF_HOME)
     os.makedirs(settings.UPLOAD_DIR, exist_ok=True)
     os.makedirs(settings.HF_HOME, exist_ok=True)
+
+    arq_redis = await create_pool(
+        RedisSettings(
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            database=settings.REDIS_DB,
+        )
+    )
+    app.state.arq_redis = arq_redis
 
     app.state.semantic_cache = None
     if settings.SEMANTIC_CACHE_ENABLED:
@@ -39,7 +57,40 @@ async def lifespan(app: FastAPI):
         except Exception:
             pass
 
+    app.state.rag_pipeline = None
+    try:
+        embedder = get_embedder()
+        vector_store = VectorStore(
+            host=settings.QDRANT_HOST,
+            port=settings.QDRANT_PORT,
+        )
+        vector_store.setup()
+        reranker = Reranker(model_name=settings.RERANKER_MODEL)
+        api_key = (
+            settings.GROQ_API_KEY
+            if settings.LLM_PROVIDER == "groq"
+            else settings.GOOGLE_API_KEY
+        )
+        llm_client = create_llm_client(settings.LLM_PROVIDER, api_key)
+        app.state.rag_pipeline = RAGPipeline(
+            embedder=embedder,
+            vector_store=vector_store,
+            reranker=reranker,
+            llm_client=llm_client,
+            cache=app.state.semantic_cache,
+            search_top_k=settings.HYBRID_SEARCH_TOP_K,
+            final_top_k=settings.FINAL_TOP_K,
+        )
+    except Exception as e:
+        logging.getLogger(__name__).warning(f"RAG pipeline başlatılamadı: {e}")
+
     yield
+
+    if hasattr(app.state, "arq_redis") and app.state.arq_redis is not None:
+        try:
+            await app.state.arq_redis.aclose()
+        except Exception:
+            pass
 
     if hasattr(app.state, "redis_client") and app.state.redis_client is not None:
         try:
@@ -68,3 +119,4 @@ app.include_router(documents.router, prefix="/api/routes/documents", tags=["docu
 app.include_router(upload.router,    prefix="/api/routes/upload",    tags=["upload"])
 app.include_router(chat.router,      prefix="/api/routes/chat",      tags=["chat"])
 app.include_router(summarize.router, prefix="/api/routes/summarize", tags=["summarize"])
+app.include_router(tasks.router,     prefix="/api/routes/tasks",     tags=["tasks"])

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -1,0 +1,29 @@
+from enum import Enum
+from typing import Optional
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class TaskStatus(str, Enum):
+    pending = "pending"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    not_found = "not_found"
+
+
+class TaskResponse(BaseModel):
+    job_id: str
+    status: TaskStatus
+    filename: Optional[str] = None
+    created_at: Optional[datetime] = None
+    result: Optional[dict] = None
+    error: Optional[str] = None
+
+
+class TaskProgressEvent(BaseModel):
+    job_id: str
+    event: str
+    stage: Optional[str] = None
+    message: Optional[str] = None

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 
 class DocumentUploadResponse(BaseModel):
+    job_id: str
     document_id: str
     filename: str
     status: str

--- a/backend/app/workers/ingestion_worker.py
+++ b/backend/app/workers/ingestion_worker.py
@@ -1,22 +1,83 @@
+import json
+import logging
+import os
+
 from arq.connections import RedisSettings
 
 from app.config import get_settings
+from app.core.embedder import get_embedder
+from app.core.llm_client import create_llm_client
+from app.core.rag_pipeline import RAGPipeline
+from app.core.reranker import Reranker
+from app.core.vector_store import VectorStore
 
 settings = get_settings()
+logger = logging.getLogger(__name__)
 
 
-async def ingest_document(ctx, document_id: str, file_path: str):
-    # RAG pipeline buraya bağlanacak
-    # await rag_pipeline.process(document_id, file_path)
-    pass
+async def ingest_document(ctx: dict, document_id: str, file_path: str) -> dict:
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    job_id: str = ctx["job_id"]
+    redis = ctx["redis"]
+    pipeline: RAGPipeline = ctx["rag_pipeline"]
+
+    async def _write_progress(stage: str, pct: int, event: str = "progress") -> None:
+        await redis.set(
+            f"progress:{job_id}",
+            json.dumps({"stage": stage, "pct": pct, "event": event}),
+            ex=3600,
+        )
+
+    try:
+        await _write_progress("parsing", 10)
+        await _write_progress("embedding", 40)
+        result = await pipeline.ingest_document(
+            file_path=file_path,
+            doc_id=document_id,
+            session_id="default",
+        )
+        await _write_progress("indexing", 80)
+        await _write_progress("done", 100, event="done")
+        logger.info("Document %s ingested: %s", document_id, result)
+        return result
+    except Exception:
+        logger.exception("Failed to ingest document %s", document_id)
+        await redis.set(
+            f"progress:{job_id}",
+            json.dumps({"stage": "failed", "pct": 0, "event": "error", "message": "Ingestion failed"}),
+            ex=3600,
+        )
+        raise
 
 
-async def startup(ctx):
-    pass
+async def startup(ctx: dict) -> None:
+    await ctx["redis"].ping()
+    logger.info("Redis connection OK")
+
+    embedder = get_embedder()
+    vector_store = VectorStore(host=settings.QDRANT_HOST, port=settings.QDRANT_PORT)
+    vector_store.setup()
+    reranker = Reranker(model_name=settings.RERANKER_MODEL)
+
+    api_key = settings.GROQ_API_KEY if settings.LLM_PROVIDER == "groq" else settings.GOOGLE_API_KEY
+    llm_client = create_llm_client(provider=settings.LLM_PROVIDER, api_key=api_key)
+
+    pipeline = RAGPipeline(
+        embedder=embedder,
+        vector_store=vector_store,
+        reranker=reranker,
+        llm_client=llm_client,
+        search_top_k=settings.HYBRID_SEARCH_TOP_K,
+        final_top_k=settings.FINAL_TOP_K,
+    )
+    ctx["rag_pipeline"] = pipeline
+    logger.info("RAG pipeline initialized")
 
 
-async def shutdown(ctx):
-    pass
+async def shutdown(ctx: dict) -> None:
+    logger.info("Worker shutting down")
 
 
 class WorkerSettings:
@@ -28,3 +89,5 @@ class WorkerSettings:
         port=settings.REDIS_PORT,
         database=settings.REDIS_DB,
     )
+    job_timeout = 300
+    max_tries = 3

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 
 @pytest.fixture
@@ -13,3 +13,83 @@ def mock_cache():
 @pytest.fixture
 def sample_doc_id():
     return "doc-test-001"
+
+
+# ── Faz 6 fixture'ları ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_pipeline():
+    """Tüm async metodları AsyncMock olan sahte RAGPipeline."""
+    pipeline = MagicMock()
+    pipeline.ingest_document = AsyncMock(return_value={
+        "doc_id": "doc-test-001",
+        "parent_count": 3,
+        "child_count": 9,
+    })
+    pipeline.query = AsyncMock(return_value=(
+        "Sözleşme 30 gün bildirim gerektirir.",
+        [{"filename": "test.pdf", "page_number": 1, "doc_id": "doc-test-001"}],
+    ))
+
+    async def _token_stream(*args, **kwargs):
+        for token in ["Bu ", "bir ", "test ", "cevabıdır."]:
+            yield token
+
+    pipeline.query_stream = _token_stream
+    return pipeline
+
+
+@pytest.fixture
+def mock_arq_job():
+    """ARQ Job lifecycle'ını simüle eder: queued → in_progress → complete."""
+    from arq.jobs import JobStatus
+
+    job = MagicMock()
+    job.job_id = "job-test-001"
+    job.status = AsyncMock(return_value=JobStatus.queued)
+    job.result_info = AsyncMock(return_value=None)
+    job.result = AsyncMock(return_value={
+        "doc_id": "doc-test-001",
+        "parent_count": 3,
+        "child_count": 9,
+    })
+    return job
+
+
+@pytest.fixture
+def mock_arq_redis():
+    """enqueue_job() döndüren ARQ pool mock'u."""
+    pool = AsyncMock()
+    job = MagicMock()
+    job.job_id = "job-enqueue-001"
+    pool.enqueue_job = AsyncMock(return_value=job)
+    return pool
+
+
+@pytest.fixture
+def worker_ctx(mock_pipeline):
+    """ingest_document(ctx, ...) için {job_id, rag_pipeline, redis} dict'i."""
+    return {
+        "job_id": "job-ctx-001",
+        "rag_pipeline": mock_pipeline,
+        "redis": AsyncMock(),
+    }
+
+
+@pytest.fixture
+def sample_pdf_bytes():
+    """PyMuPDF'in parse edebileceği minimal geçerli PDF."""
+    return (
+        b"%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+        b"xref\n0 4\n0000000000 65535 f \n"
+        b"trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n9\n%%EOF"
+    )
+
+
+@pytest.fixture
+def corrupted_pdf_bytes():
+    """PDF header'ına benzeyip parse edilemeyen bozuk içerik."""
+    return b"%PDF-1.4\nGARBAGE INVALID CONTENT \x00\x01\x02\x03"

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,69 @@
+"""
+Integration test conftest — lokal ortamda kurulu olmayan ML/veritabanı
+kütüphaneleri için sys.modules stub'ları. pytest bu dosyayı test modüllerini
+toplamadan önce yükler, dolayısıyla module-level import'lar çalışır.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+_EMPTY_MODULES = [
+    "llama_index",
+    "llama_index.core",
+    "llama_index.core.node_parser",
+    "llama_index.core.schema",
+    "fitz",
+    "docx",
+    "langdetect",
+    "FlagEmbedding",
+    "surya",
+    "surya.recognition",
+    "surya.detection",
+    "surya.layout",
+    "surya.model",
+    "qdrant_client",
+    "qdrant_client.models",
+    "qdrant_client.http",
+    "qdrant_client.http.models",
+]
+
+for _mod_name in _EMPTY_MODULES:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = types.ModuleType(_mod_name)
+
+# llama_index stub'ları
+if not hasattr(sys.modules["llama_index.core.node_parser"], "SentenceSplitter"):
+    sys.modules["llama_index.core.node_parser"].SentenceSplitter = MagicMock
+
+# docx stub
+if not hasattr(sys.modules["docx"], "Document"):
+    sys.modules["docx"].Document = type("Document", (), {"__init__": lambda *a, **k: None})
+
+# langdetect stub
+if not hasattr(sys.modules["langdetect"], "detect"):
+    sys.modules["langdetect"].detect = lambda x: "tr"
+    sys.modules["langdetect"].LangDetectException = Exception
+
+# FlagEmbedding stub
+_fe = sys.modules["FlagEmbedding"]
+if not hasattr(_fe, "BGEM3FlagModel"):
+    _fe.BGEM3FlagModel = type("BGEM3FlagModel", (), {"__init__": lambda *a, **k: None})
+if not hasattr(_fe, "FlagReranker"):
+    _fe.FlagReranker = type("FlagReranker", (), {"__init__": lambda *a, **k: None})
+
+# qdrant_client stub'ları — vector_store.py'deki from qdrant_client.models import (...)
+_qdrant_symbols = [
+    "Distance", "FieldCondition", "Filter", "Fusion", "FusionQuery",
+    "MatchAny", "MatchValue", "PayloadSchemaType", "PointStruct",
+    "Prefetch", "SparseVector", "SparseVectorParams", "VectorParams",
+    "VectorsConfig", "SparseVectorsConfig",
+]
+_qm = sys.modules["qdrant_client.models"]
+for _sym in _qdrant_symbols:
+    if not hasattr(_qm, _sym):
+        setattr(_qm, _sym, type(_sym, (), {}))
+
+_qc = sys.modules["qdrant_client"]
+if not hasattr(_qc, "QdrantClient"):
+    _qc.QdrantClient = type("QdrantClient", (), {"__init__": lambda *a, **k: None})

--- a/backend/tests/integration/test_chat_streaming_e2e.py
+++ b/backend/tests/integration/test_chat_streaming_e2e.py
@@ -1,0 +1,221 @@
+"""
+Faz 6.2 — Chat Streaming Uçtan Uca Testleri
+
+Strateji: chat_stream() fonksiyonu doğrudan çağrılır, StreamingResponse.body_iterator
+async for ile iterate edilir, SSE satırları parse edilir, event sözleşmesi doğrulanır.
+
+SSE Sözleşmesi:
+    data: {"type": "token", "content": "..."}
+    data: {"type": "sources", "documents": [...]}
+    data: {"type": "done"}
+    data: {"type": "error", "message": "..."}
+"""
+
+import asyncio
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from fastapi import HTTPException
+
+from app.api.routes.chat import chat, chat_stream
+from app.services.chat_service import ChatRequest
+
+
+# ── Yardımcı fonksiyonlar ─────────────────────────────────────────────────────
+
+def _chat_request(
+    question="Sözleşmenin fesih maddesi nedir?",
+    session_id="sess-stream-001",
+    doc_ids=None,
+):
+    return ChatRequest(
+        question=question,
+        session_id=session_id,
+        document_ids=doc_ids or ["doc-test-001"],
+    )
+
+
+def _mock_request(pipeline=None):
+    req = MagicMock()
+    req.app.state.rag_pipeline = pipeline
+    return req
+
+
+async def _collect_sse_events(streaming_response) -> list[dict]:
+    """StreamingResponse.body_iterator'ı iterate edip SSE event'leri parse eder."""
+    events = []
+    async for chunk in streaming_response.body_iterator:
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8")
+        for line in chunk.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[len("data:"):].strip()
+                if payload:
+                    events.append(json.loads(payload))
+    return events
+
+
+def _make_token_gen(*tokens):
+    """Belirtilen token'ları yield eden async generator factory'si döndürür."""
+    async def _gen(*args, **kwargs):
+        for token in tokens:
+            yield token
+    return _gen
+
+
+# ── SSE Sözleşme Testleri ─────────────────────────────────────────────────────
+
+class TestChatStreamSSEContract:
+    """chat_stream() endpoint'inin SSE event formatını ve sırasını doğrular."""
+
+    async def test_token_event_formatı_doğru(self, mock_pipeline):
+        """Her token {type: token, content: str} formatında iletilmeli."""
+        mock_pipeline.query_stream = _make_token_gen("Sözleşme", " 30", " gün.")
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        token_events = [e for e in events if e.get("type") == "token"]
+        assert len(token_events) >= 1
+        for evt in token_events:
+            assert "content" in evt
+            assert isinstance(evt["content"], str)
+
+    async def test_done_event_son_gelir(self, mock_pipeline):
+        """Son event her zaman {type: done} olmalı."""
+        mock_pipeline.query_stream = _make_token_gen("merhaba")
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        assert events, "Hiç SSE event toplanamadı."
+        assert events[-1]["type"] == "done"
+
+    async def test_token_sirasi_korunur(self, mock_pipeline):
+        """Token'lar generator'ın ürettiği sırayla iletilmeli."""
+        tokens = ["Birinci", " ikinci", " üçüncü."]
+        mock_pipeline.query_stream = _make_token_gen(*tokens)
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        token_events = [e for e in events if e.get("type") == "token"]
+        contents = [e["content"] for e in token_events]
+        assert contents == tokens
+
+    async def test_bos_soru_400_firlatir(self):
+        """Boş veya whitespace-only soru → 400 HTTPException yükselmeli."""
+        with pytest.raises(HTTPException) as exc:
+            await chat_stream(_chat_request(question="   "), _mock_request())
+        assert exc.value.status_code == 400
+
+    async def test_media_type_event_stream(self, mock_pipeline):
+        """StreamingResponse media_type = 'text/event-stream' olmalı."""
+        mock_pipeline.query_stream = _make_token_gen("tok")
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        assert response.media_type == "text/event-stream"
+
+    async def test_cache_control_no_cache_header(self, mock_pipeline):
+        """SSE response Cache-Control: no-cache header'ı içermeli."""
+        mock_pipeline.query_stream = _make_token_gen("tok")
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        assert response.headers.get("Cache-Control") == "no-cache"
+
+    async def test_pipeline_none_ise_error_event_gönderilir(self):
+        """Pipeline None ise {type: error} event'i gönderilmeli, exception fırlatılmamalı."""
+        req = _mock_request(pipeline=None)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1
+
+    async def test_sources_dict_event_iletilir(self, mock_pipeline):
+        """
+        Generator __sources__ anahtarlı dict yield ederse,
+        {type: sources, documents: [...]} event'i gönderilmeli.
+        """
+        async def _gen_with_sources(*args, **kwargs):
+            yield "Cevap metni."
+            yield {"__sources__": [{"filename": "test.pdf", "doc_id": "doc-001"}]}
+
+        mock_pipeline.query_stream = _gen_with_sources
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        sources_events = [e for e in events if e.get("type") == "sources"]
+        assert len(sources_events) == 1
+        assert "documents" in sources_events[0]
+        assert isinstance(sources_events[0]["documents"], list)
+
+    async def test_exception_sirasinda_error_event_gönderilir(self, mock_pipeline):
+        """Generator exception fırlatırsa SSE error event gönderilmeli, stream kapanmalı."""
+        async def _crashing_gen(*args, **kwargs):
+            yield "başlıyor"
+            raise RuntimeError("LLM API 503 döndü")
+
+        mock_pipeline.query_stream = _crashing_gen
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1
+        assert "message" in error_events[0]
+
+    async def test_timeout_error_event_gönderilir(self, mock_pipeline):
+        """asyncio.TimeoutError → SSE error event, server çökmemeli."""
+        async def _timeout_gen(*args, **kwargs):
+            yield "hazırlanıyor"
+            raise asyncio.TimeoutError("LLM yanıt vermedi")
+
+        mock_pipeline.query_stream = _timeout_gen
+        req = _mock_request(mock_pipeline)
+
+        response = await chat_stream(_chat_request(), req)
+        events = await _collect_sse_events(response)
+
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1
+
+
+# ── Chat (non-streaming) Endpoint Testleri ────────────────────────────────────
+
+class TestChatNonStreaming:
+    """chat() (non-streaming) endpoint'inin temel davranışını doğrular."""
+
+    async def test_pipeline_sonucu_döndürür(self, mock_pipeline):
+        """Pipeline query çağrısı yanıtı ChatResponse olarak dönmeli."""
+        req = _mock_request(mock_pipeline)
+
+        result = await chat(_chat_request(), req)
+
+        assert result.question == "Sözleşmenin fesih maddesi nedir?"
+        assert result.answer == "Sözleşme 30 gün bildirim gerektirir."
+
+    async def test_pipeline_none_fallback_yanit(self):
+        """Pipeline None ise fallback mesajlı ChatResponse dönmeli."""
+        req = _mock_request(pipeline=None)
+
+        result = await chat(_chat_request(), req)
+
+        assert result is not None
+        assert result.question == "Sözleşmenin fesih maddesi nedir?"
+
+    async def test_bos_soru_400_firlatir(self):
+        """Boş soru → 400 HTTPException."""
+        with pytest.raises(HTTPException) as exc:
+            await chat(_chat_request(question=""), _mock_request())
+        assert exc.value.status_code == 400

--- a/backend/tests/integration/test_worker_integration.py
+++ b/backend/tests/integration/test_worker_integration.py
@@ -1,0 +1,229 @@
+"""
+Faz 6.1 — Worker Entegrasyon Testleri
+
+Kapsam:
+- ingest_document() worker fonksiyonunun pipeline ile doğru entegrasyonu
+- ARQ job lifecycle → API status eşleşme sözleşmesi
+- startup() fonksiyonunun ctx'i doğru doldurduğu
+"""
+
+import os
+import tempfile
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ağır ML/DB bağımlılıkları tests/integration/conftest.py'de stub'lanmıştır.
+from app.workers.ingestion_worker import ingest_document, startup
+from app.core.document_processor import DocumentProcessingError
+
+
+class TestIngestDocumentWorkerFunction:
+    """ingest_document() ARQ worker fonksiyonunun izolasyon testleri."""
+
+    async def test_pipeline_dogru_argümanlarla_cagrilir(self, worker_ctx, sample_doc_id):
+        """ingest_document(), pipeline.ingest_document()'i file_path ve doc_id ile çağırmalı."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 test")
+            tmp_path = f.name
+        try:
+            await ingest_document(worker_ctx, sample_doc_id, tmp_path)
+            worker_ctx["rag_pipeline"].ingest_document.assert_awaited_once_with(
+                file_path=tmp_path,
+                doc_id=sample_doc_id,
+                session_id="default",
+            )
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_pipeline_sonucu_döndürülür(self, worker_ctx, sample_doc_id):
+        """ingest_document(), pipeline'dan gelen sonucu geri döndürmeli."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 test")
+            tmp_path = f.name
+        try:
+            result = await ingest_document(worker_ctx, sample_doc_id, tmp_path)
+            assert result["doc_id"] == sample_doc_id
+            assert result["parent_count"] == 3
+            assert result["child_count"] == 9
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_dosya_yoksa_filenotfounderror_firlatilir(self, worker_ctx):
+        """Var olmayan dosya yolu verildiğinde FileNotFoundError yükselmeli."""
+        with pytest.raises(FileNotFoundError):
+            await ingest_document(worker_ctx, "doc-missing", "/nonexistent/path/file.pdf")
+
+    async def test_pipeline_exception_re_raise_edilir(self, worker_ctx):
+        """Pipeline hata fırlatırsa worker re-raise etmeli; ARQ job'ı failed olarak işaretler."""
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=DocumentProcessingError("bozuk PDF")
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"bad content")
+            tmp_path = f.name
+        try:
+            with pytest.raises(DocumentProcessingError):
+                await ingest_document(worker_ctx, "doc-bad", tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_basari_durumunda_info_log_atilir(self, worker_ctx, caplog):
+        """Başarılı ingest sonrası document_id içeren INFO log olmalı."""
+        import logging
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 test")
+            tmp_path = f.name
+        try:
+            with caplog.at_level(logging.INFO, logger="app.workers.ingestion_worker"):
+                await ingest_document(worker_ctx, "doc-log-001", tmp_path)
+            assert "doc-log-001" in caplog.text
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_hata_durumunda_exception_log_atilir(self, worker_ctx, caplog):
+        """Pipeline hatası sonrası document_id içeren hata logu olmalı."""
+        import logging
+
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=RuntimeError("LLM patladı")
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            tmp_path = f.name
+        try:
+            with caplog.at_level(logging.ERROR, logger="app.workers.ingestion_worker"):
+                with pytest.raises(RuntimeError):
+                    await ingest_document(worker_ctx, "doc-fail", tmp_path)
+            assert "doc-fail" in caplog.text
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_progress_redis_e_yazilir(self, worker_ctx, sample_doc_id):
+        """İngest sırasında Redis'e progress kaydı yapılmalı."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 test")
+            tmp_path = f.name
+        try:
+            await ingest_document(worker_ctx, sample_doc_id, tmp_path)
+            assert worker_ctx["redis"].set.await_count >= 1
+        finally:
+            os.unlink(tmp_path)
+
+    async def test_hata_durumunda_error_progress_yazilir(self, worker_ctx):
+        """Pipeline hatası durumunda Redis'e 'error' event'li progress yazılmalı."""
+        import json
+
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=RuntimeError("hata")
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            tmp_path = f.name
+        try:
+            with pytest.raises(RuntimeError):
+                await ingest_document(worker_ctx, "doc-err-progress", tmp_path)
+
+            written_calls = worker_ctx["redis"].set.call_args_list
+            last_data = json.loads(written_calls[-1].args[1])
+            assert last_data["event"] == "error"
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestArqJobLifecycle:
+    """
+    ARQ JobStatus değerlerinin API status sözleşmesiyle eşleşmesini doğrular.
+
+    ARQ'da 'failed' enum yoktur: başarısız job → complete + success=False.
+    Task status endpoint bu eşleştirmeyi yapmalı.
+    """
+
+    async def test_queued_status(self, mock_arq_job):
+        """Kuyruğa alınmış job → queued durumu döner."""
+        from arq.jobs import JobStatus
+
+        mock_arq_job.status = AsyncMock(return_value=JobStatus.queued)
+        status = await mock_arq_job.status()
+        assert status == JobStatus.queued
+
+    async def test_in_progress_status(self, mock_arq_job):
+        """Çalışan job → in_progress durumu döner."""
+        from arq.jobs import JobStatus
+
+        mock_arq_job.status = AsyncMock(return_value=JobStatus.in_progress)
+        status = await mock_arq_job.status()
+        assert status == JobStatus.in_progress
+
+    async def test_complete_success(self, mock_arq_job):
+        """Başarıyla tamamlanan job → complete + success=True."""
+        from arq.jobs import JobStatus, JobResult
+
+        mock_arq_job.status = AsyncMock(return_value=JobStatus.complete)
+        result_info = MagicMock(spec=JobResult)
+        result_info.success = True
+        result_info.result = {"doc_id": "doc-001", "parent_count": 3, "child_count": 9}
+        mock_arq_job.result_info = AsyncMock(return_value=result_info)
+
+        status = await mock_arq_job.status()
+        info = await mock_arq_job.result_info()
+        assert status == JobStatus.complete
+        assert info.success is True
+
+    async def test_complete_with_failure(self, mock_arq_job):
+        """Hata fırlatan job → complete + success=False (API'de 'failed' olarak gösterilmeli)."""
+        from arq.jobs import JobStatus, JobResult
+
+        mock_arq_job.status = AsyncMock(return_value=JobStatus.complete)
+        result_info = MagicMock(spec=JobResult)
+        result_info.success = False
+        result_info.result = RuntimeError("PDF bozuk")
+        mock_arq_job.result_info = AsyncMock(return_value=result_info)
+
+        status = await mock_arq_job.status()
+        info = await mock_arq_job.result_info()
+        assert status == JobStatus.complete
+        assert info.success is False
+
+    async def test_not_found_status(self, mock_arq_job):
+        """Bilinmeyen job_id → not_found durumu döner."""
+        from arq.jobs import JobStatus
+
+        mock_arq_job.status = AsyncMock(return_value=JobStatus.not_found)
+        status = await mock_arq_job.status()
+        assert status == JobStatus.not_found
+
+
+class TestWorkerStartupContext:
+    """startup() fonksiyonunun ctx'i doğru şekilde doldurduğunu doğrular."""
+
+    async def test_startup_redis_ping_yapar(self):
+        """startup() Redis bağlantısını test etmek için ping() çağırmalı."""
+        ctx = {"redis": AsyncMock()}
+
+        with (
+            patch("app.workers.ingestion_worker.get_embedder", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.VectorStore") as mock_vs_cls,
+            patch("app.workers.ingestion_worker.Reranker", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.create_llm_client", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.RAGPipeline", return_value=MagicMock()),
+        ):
+            mock_vs_cls.return_value.setup = MagicMock()
+            await startup(ctx)
+
+        ctx["redis"].ping.assert_awaited_once()
+
+    async def test_startup_rag_pipeline_set_eder(self):
+        """startup() sonrası ctx['rag_pipeline'] bir RAGPipeline instance'ı olmalı."""
+        ctx = {"redis": AsyncMock()}
+        fake_pipeline = MagicMock()
+
+        with (
+            patch("app.workers.ingestion_worker.get_embedder", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.VectorStore") as mock_vs_cls,
+            patch("app.workers.ingestion_worker.Reranker", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.create_llm_client", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.RAGPipeline", return_value=fake_pipeline),
+        ):
+            mock_vs_cls.return_value.setup = MagicMock()
+            await startup(ctx)
+
+        assert ctx["rag_pipeline"] is fake_pipeline

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,0 +1,63 @@
+"""
+Unit test conftest — test_error_scenarios.py'nin ingestion_worker importu için
+gerekli ML/DB kütüphane stub'ları. Conftest test modüllerinden önce yüklenir.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+_EMPTY_MODULES = [
+    "llama_index",
+    "llama_index.core",
+    "llama_index.core.node_parser",
+    "llama_index.core.schema",
+    "fitz",
+    "docx",
+    "langdetect",
+    "FlagEmbedding",
+    "surya",
+    "surya.recognition",
+    "surya.detection",
+    "surya.layout",
+    "surya.model",
+    "qdrant_client",
+    "qdrant_client.models",
+    "qdrant_client.http",
+    "qdrant_client.http.models",
+]
+
+for _mod_name in _EMPTY_MODULES:
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = types.ModuleType(_mod_name)
+
+if not hasattr(sys.modules["llama_index.core.node_parser"], "SentenceSplitter"):
+    sys.modules["llama_index.core.node_parser"].SentenceSplitter = MagicMock
+
+if not hasattr(sys.modules["docx"], "Document"):
+    sys.modules["docx"].Document = type("Document", (), {"__init__": lambda *a, **k: None})
+
+if not hasattr(sys.modules["langdetect"], "detect"):
+    sys.modules["langdetect"].detect = lambda x: "tr"
+    sys.modules["langdetect"].LangDetectException = Exception
+
+_fe = sys.modules["FlagEmbedding"]
+if not hasattr(_fe, "BGEM3FlagModel"):
+    _fe.BGEM3FlagModel = type("BGEM3FlagModel", (), {"__init__": lambda *a, **k: None})
+if not hasattr(_fe, "FlagReranker"):
+    _fe.FlagReranker = type("FlagReranker", (), {"__init__": lambda *a, **k: None})
+
+_qdrant_symbols = [
+    "Distance", "FieldCondition", "Filter", "Fusion", "FusionQuery",
+    "MatchAny", "MatchValue", "PayloadSchemaType", "PointStruct",
+    "Prefetch", "SparseVector", "SparseVectorParams", "VectorParams",
+    "VectorsConfig", "SparseVectorsConfig",
+]
+_qm = sys.modules["qdrant_client.models"]
+for _sym in _qdrant_symbols:
+    if not hasattr(_qm, _sym):
+        setattr(_qm, _sym, type(_sym, (), {}))
+
+_qc = sys.modules["qdrant_client"]
+if not hasattr(_qc, "QdrantClient"):
+    _qc.QdrantClient = type("QdrantClient", (), {"__init__": lambda *a, **k: None})

--- a/backend/tests/unit/test_api_chat.py
+++ b/backend/tests/unit/test_api_chat.py
@@ -15,39 +15,45 @@ def _req(question="Belgedeki madde 5 nedir?", doc_ids=None):
     )
 
 
-def _http_req(cache=None):
+def _http_req(pipeline=None):
     r = MagicMock()
-    r.app.state.semantic_cache = cache
+    r.app.state.rag_pipeline = pipeline
     return r
 
 
+def _mock_pipeline(answer="Test cevabı", sources=None):
+    p = MagicMock()
+    p.query = AsyncMock(return_value=(answer, sources or []))
+    return p
+
+
+@pytest.mark.asyncio
 async def test_bos_soru_400_dondurur():
     with pytest.raises(HTTPException) as exc:
         await chat(_req(question="   "), _http_req())
     assert exc.value.status_code == 400
 
 
-async def test_cache_yok_placeholder_doner():
-    result = await chat(_req(), _http_req(cache=None))
+@pytest.mark.asyncio
+async def test_pipeline_yok_placeholder_doner():
+    result = await chat(_req(), _http_req(pipeline=None))
     assert result.question == "Belgedeki madde 5 nedir?"
+    assert "hazır değil" in result.answer
     assert isinstance(result.sources, list)
 
 
-async def test_cache_hit_dogrudan_doner():
-    cached = {
-        "question": "önbellekli soru",
-        "answer": "önbellekten gelen cevap",
-        "sources": [],
-    }
-    mock_cache = AsyncMock()
-    mock_cache.get = AsyncMock(return_value=cached)
-
-    result = await chat(_req(question="önbellekli soru"), _http_req(cache=mock_cache))
-    assert result.answer == "önbellekten gelen cevap"
-    mock_cache.set.assert_not_called()
+@pytest.mark.asyncio
+async def test_pipeline_cevap_doner():
+    pipeline = _mock_pipeline(answer="Madde 5 şunu der...")
+    result = await chat(_req(), _http_req(pipeline=pipeline))
+    assert result.answer == "Madde 5 şunu der..."
+    pipeline.query.assert_awaited_once()
 
 
-async def test_cache_miss_kaydedilir(mock_cache):
-    result = await chat(_req(), _http_req(cache=mock_cache))
-    mock_cache.set.assert_called_once()
-    assert result is not None
+@pytest.mark.asyncio
+async def test_pipeline_kaynak_doner():
+    sources = [{"doc_id": "abc", "filename": "test.pdf"}]
+    pipeline = _mock_pipeline(sources=sources)
+    result = await chat(_req(), _http_req(pipeline=pipeline))
+    assert len(result.sources) == 1
+    assert result.sources[0].filename == "test.pdf"

--- a/backend/tests/unit/test_api_documents.py
+++ b/backend/tests/unit/test_api_documents.py
@@ -1,20 +1,59 @@
-from app.api.routes.documents import delete_document, list_documents
+from unittest.mock import MagicMock
+from datetime import datetime, timezone
+
+import pytest
+
+from app.api.routes.documents import list_documents, delete_document
 
 
+def _make_request(docs: list):
+    """Fake FastAPI Request with mocked rag_pipeline."""
+    vs_mock = MagicMock()
+    vs_mock.list_documents.return_value = docs
+    vs_mock.delete_document.return_value = None
+
+    pipeline_mock = MagicMock()
+    pipeline_mock.vector_store = vs_mock
+
+    state = MagicMock()
+    state.rag_pipeline = pipeline_mock
+
+    req = MagicMock()
+    req.app.state = state
+    return req
+
+
+@pytest.mark.asyncio
 async def test_liste_bos_donuyor():
-    result = await list_documents()
+    req = _make_request([])
+    result = await list_documents(request=req, session_id="default")
     assert result["documents"] == []
     assert result["total"] == 0
 
 
+@pytest.mark.asyncio
+async def test_liste_dolu_donuyor():
+    req = _make_request([
+        {"doc_id": "abc-123", "filename": "test.pdf", "chunk_count": 5},
+    ])
+    result = await list_documents(request=req, session_id="default")
+    assert result["total"] == 1
+    assert result["documents"][0].document_id == "abc-123"
+    assert result["documents"][0].filename == "test.pdf"
+
+
+@pytest.mark.asyncio
 async def test_silme_basarili_donus():
-    result = await delete_document("doc-xyz-123")
+    req = _make_request([])
+    result = await delete_document(document_id="doc-xyz-123", request=req, session_id="default")
     assert result.document_id == "doc-xyz-123"
     assert result.deleted is True
 
 
+@pytest.mark.asyncio
 async def test_silme_farkli_id():
-    r1 = await delete_document("id-aaa")
-    r2 = await delete_document("id-bbb")
+    req = _make_request([])
+    r1 = await delete_document(document_id="id-aaa", request=req, session_id="default")
+    r2 = await delete_document(document_id="id-bbb", request=req, session_id="default")
     assert r1.document_id == "id-aaa"
     assert r2.document_id == "id-bbb"

--- a/backend/tests/unit/test_api_tasks.py
+++ b/backend/tests/unit/test_api_tasks.py
@@ -1,0 +1,166 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+import pytest
+
+from arq.jobs import JobStatus
+
+from app.api.routes.tasks import get_task_status
+from app.models.task import TaskStatus
+
+
+def _make_request(arq_redis):
+    state = MagicMock()
+    state.arq_redis = arq_redis
+    req = MagicMock()
+    req.app.state = state
+    return req
+
+
+def _make_arq_redis():
+    arq_mock = AsyncMock()
+    arq_mock.get = AsyncMock(return_value=None)
+    return arq_mock
+
+
+def _make_job(status: JobStatus, result=None, error=None):
+    info_mock = MagicMock()
+    info_mock.enqueue_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    job_mock = AsyncMock()
+    job_mock.status = AsyncMock(return_value=status)
+    job_mock.info = AsyncMock(return_value=info_mock)
+
+    if error:
+        job_mock.result = AsyncMock(side_effect=Exception(error))
+    else:
+        job_mock.result = AsyncMock(return_value=result)
+
+    return job_mock
+
+
+@pytest.mark.asyncio
+async def test_task_status_pending():
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.queued)):
+        result = await get_task_status("test-job-id", req)
+
+    assert result.job_id == "test-job-id"
+    assert result.status == TaskStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_task_status_running():
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.in_progress)):
+        result = await get_task_status("test-job-id", req)
+
+    assert result.status == TaskStatus.running
+
+
+@pytest.mark.asyncio
+async def test_task_status_completed():
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.complete, result={"doc_id": "abc"})):
+        result = await get_task_status("test-job-id", req)
+
+    assert result.status == TaskStatus.completed
+    assert result.result == {"doc_id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_task_status_not_found():
+    from fastapi import HTTPException
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.not_found)):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_task_status("nonexistent-job", req)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_task_status_failed():
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.complete, error="Pipeline error")):
+        result = await get_task_status("failed-job", req)
+
+    assert result.status == TaskStatus.failed
+    assert "Pipeline error" in result.error
+
+
+@pytest.mark.asyncio
+async def test_task_status_no_queue():
+    from fastapi import HTTPException
+    req = _make_request(None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_task_status("any-job", req)
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_task_status_deferred_returns_pending():
+    """Ertelenmiş (deferred) job → 'pending' status döndürmeli."""
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.deferred)):
+        result = await get_task_status("deferred-job", req)
+
+    assert result.status == TaskStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_task_status_response_echoes_job_id():
+    """Response her zaman gönderilen job_id değerini içermeli."""
+    arq = _make_arq_redis()
+    req = _make_request(arq)
+    test_job_id = "unique-job-xyz-789"
+
+    with patch("app.api.routes.tasks.Job", return_value=_make_job(JobStatus.queued)):
+        result = await get_task_status(test_job_id, req)
+
+    assert result.job_id == test_job_id
+
+
+@pytest.mark.asyncio
+async def test_upload_response_includes_job_id(mock_arq_redis):
+    """Upload sonrası her dosya için job_id alanı döndürülmeli."""
+    from app.api.routes.upload import upload_documents
+
+    def _dosya(ad="test.pdf"):
+        f = MagicMock()
+        f.filename = ad
+        f.read = AsyncMock(return_value=b"%PDF-1.4 test")
+        return f
+
+    def _aiofiles_mock():
+        m = AsyncMock()
+        m.write = AsyncMock()
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=m)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    req = MagicMock()
+    req.app.state.arq_redis = mock_arq_redis
+
+    with patch("aiofiles.open", return_value=_aiofiles_mock()):
+        result = await upload_documents(req, files=[_dosya()], session_id="sess-001")
+
+    assert len(result) == 1
+    assert hasattr(result[0], "job_id")
+    assert result[0].job_id == "job-enqueue-001"
+    assert result[0].status == "queued"

--- a/backend/tests/unit/test_api_upload.py
+++ b/backend/tests/unit/test_api_upload.py
@@ -22,6 +22,18 @@ def _aiofiles_mock():
     return cm
 
 
+def _http_req():
+    job_mock = MagicMock()
+    job_mock.job_id = "test-job-id"
+
+    arq_mock = AsyncMock()
+    arq_mock.enqueue_job = AsyncMock(return_value=job_mock)
+
+    r = MagicMock()
+    r.app.state.arq_redis = arq_mock
+    return r
+
+
 def test_gecersiz_uzanti_reddedilir():
     with pytest.raises(HTTPException) as exc:
         validate_file(_dosya("kotu.exe"))
@@ -43,28 +55,41 @@ def test_docx_uzantisi_kabul_edilir():
     assert ext == "docx"
 
 
+@pytest.mark.asyncio
 async def test_pdf_yukleme_queued_doner():
     with patch("aiofiles.open", return_value=_aiofiles_mock()):
-        result = await upload_documents(files=[_dosya()], session_id="sess-001")
+        result = await upload_documents(
+            request=_http_req(), files=[_dosya()], session_id="sess-001"
+        )
     assert len(result) == 1
     assert result[0].status == "queued"
     assert result[0].filename == "sozlesme.pdf"
+    assert result[0].job_id == "test-job-id"
 
 
+@pytest.mark.asyncio
 async def test_coklu_dosya_yukleme():
     dosyalar = [_dosya("a.pdf"), _dosya("b.docx"), _dosya("c.txt")]
     with patch("aiofiles.open", return_value=_aiofiles_mock()):
-        result = await upload_documents(files=dosyalar, session_id="sess-002")
+        result = await upload_documents(
+            request=_http_req(), files=dosyalar, session_id="sess-002"
+        )
     assert len(result) == 3
 
 
+@pytest.mark.asyncio
 async def test_her_dosyaya_benzersiz_id_atanir():
     dosyalar = [_dosya("x.pdf"), _dosya("y.pdf")]
     with patch("aiofiles.open", return_value=_aiofiles_mock()):
-        result = await upload_documents(files=dosyalar, session_id="s")
+        result = await upload_documents(
+            request=_http_req(), files=dosyalar, session_id="s"
+        )
     assert result[0].document_id != result[1].document_id
 
 
+@pytest.mark.asyncio
 async def test_gecersiz_uzanti_http_exception_firlatir():
     with pytest.raises(HTTPException):
-        await upload_documents(files=[_dosya("virus.sh")], session_id="s")
+        await upload_documents(
+            request=_http_req(), files=[_dosya("virus.sh")], session_id="s"
+        )

--- a/backend/tests/unit/test_error_scenarios.py
+++ b/backend/tests/unit/test_error_scenarios.py
@@ -1,0 +1,312 @@
+"""
+Faz 6.3 — Hata Senaryoları Testleri
+
+Kapsam:
+A. Bozuk/corrupted PDF → worker job 'failed' durumuna düşmeli
+B. LLM timeout → SSE 'error' event gönderilmeli
+C. Redis kesintisi → graceful degradation, çökme yok
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import HTTPException
+
+# Ağır ML/DB bağımlılıkları tests/unit/conftest.py'de stub'lanmıştır.
+from app.workers.ingestion_worker import ingest_document, startup
+from app.core.document_processor import DocumentProcessingError
+
+
+# ── Yardımcı ─────────────────────────────────────────────────────────────────
+
+async def _collect_sse_events(streaming_response) -> list[dict]:
+    """StreamingResponse.body_iterator'dan SSE event'lerini toplar."""
+    events = []
+    async for chunk in streaming_response.body_iterator:
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode("utf-8")
+        for line in chunk.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[len("data:"):].strip()
+                if payload:
+                    events.append(json.loads(payload))
+    return events
+
+
+def _stream_request(pipeline=None):
+    req = MagicMock()
+    req.app.state.rag_pipeline = pipeline
+    return req
+
+
+# ── A. Bozuk PDF Senaryoları ──────────────────────────────────────────────────
+
+class TestCorruptedPdfWorkerFailure:
+    """Bozuk PDF yüklemesi → worker job'ı failed durumuna düşmeli."""
+
+    async def test_bozuk_pdf_document_processing_error_firlatir(self, worker_ctx):
+        """
+        DocumentProcessingError fırlatıldığında worker re-raise etmeli;
+        ARQ bu hatayı yakalayarak job'ı complete+success=False yapacak.
+        """
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=DocumentProcessingError("PDF yapısı geçersiz")
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4\nGARBAGE\x00\x01")
+            tmp = f.name
+        try:
+            with pytest.raises(DocumentProcessingError) as exc:
+                await ingest_document(worker_ctx, "doc-corrupt", tmp)
+            assert "PDF" in str(exc.value) or "geçersiz" in str(exc.value)
+        finally:
+            os.unlink(tmp)
+
+    async def test_bozuk_pdf_kismi_indexleme_yapmaz(self, worker_ctx):
+        """Pipeline hata fırlatırsa vector_store.index_child_chunks çağrılmamalı."""
+        vector_store = MagicMock()
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=DocumentProcessingError("bozuk")
+        )
+        worker_ctx["rag_pipeline"].vector_store = vector_store
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"GARBAGE")
+            tmp = f.name
+        try:
+            with pytest.raises(DocumentProcessingError):
+                await ingest_document(worker_ctx, "doc-corrupt-2", tmp)
+            vector_store.index_child_chunks.assert_not_called()
+        finally:
+            os.unlink(tmp)
+
+    async def test_bos_dosya_hata_firlatir(self, worker_ctx):
+        """Boş dosya → FileNotFoundError veya DocumentProcessingError yükselmeli."""
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=DocumentProcessingError("metin çıkarılamadı")
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            tmp = f.name
+        try:
+            with pytest.raises((DocumentProcessingError, FileNotFoundError)):
+                await ingest_document(worker_ctx, "doc-empty", tmp)
+        finally:
+            os.unlink(tmp)
+
+    async def test_arq_failed_semantigi(self):
+        """
+        ARQ'da 'failed' enum yoktur: başarısız job → complete + success=False.
+        Task endpoint bu eşleştirmeyi yapmalı.
+        """
+        from arq.jobs import JobStatus, JobResult
+
+        job = MagicMock()
+        job.status = AsyncMock(return_value=JobStatus.complete)
+        result_info = MagicMock(spec=JobResult)
+        result_info.success = False
+        result_info.result = DocumentProcessingError("PDF yapısı geçersiz")
+        job.result_info = AsyncMock(return_value=result_info)
+
+        status = await job.status()
+        info = await job.result_info()
+        assert status == JobStatus.complete
+        assert info.success is False
+
+    async def test_hata_sonrasi_redis_e_error_event_yazilir(self, worker_ctx):
+        """Worker hata durumunda Redis'e 'error' event'li progress kaydı yapmalı."""
+        worker_ctx["rag_pipeline"].ingest_document = AsyncMock(
+            side_effect=DocumentProcessingError("hata")
+        )
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"bad")
+            tmp = f.name
+        try:
+            with pytest.raises(DocumentProcessingError):
+                await ingest_document(worker_ctx, "doc-redis-err", tmp)
+
+            written_calls = worker_ctx["redis"].set.call_args_list
+            last_data = json.loads(written_calls[-1].args[1])
+            assert last_data["event"] == "error"
+        finally:
+            os.unlink(tmp)
+
+
+# ── B. LLM Timeout Senaryoları ────────────────────────────────────────────────
+
+class TestLLMTimeoutSSEError:
+    """LLM timeout → SSE error event gönderilmeli, server çökmemeli."""
+
+    def _make_timeout_gen(self):
+        async def _gen(*args, **kwargs):
+            yield "Yanıt hazırlanıyor"
+            raise asyncio.TimeoutError("LLM yanıt vermedi")
+        return _gen
+
+    async def test_timeout_error_event_gönderir(self):
+        """asyncio.TimeoutError → SSE {type: error} event."""
+        from app.api.routes.chat import chat_stream
+        from app.services.chat_service import ChatRequest
+
+        pipeline = MagicMock()
+        pipeline.query_stream = self._make_timeout_gen()
+
+        req = _stream_request(pipeline)
+        chat_req = ChatRequest(
+            question="Sözleşme ne zaman bitiyor?",
+            session_id="sess-timeout",
+            document_ids=["doc-001"],
+        )
+
+        response = await chat_stream(chat_req, req)
+        events = await _collect_sse_events(response)
+
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1, f"Beklenen 1 error event, alınan: {events}"
+        assert "message" in error_events[0]
+
+    async def test_timeout_sunucuyu_cökermiyor(self):
+        """TimeoutError stream'e absorbe edilmeli, unhandled exception olmamalı."""
+        from app.api.routes.chat import chat_stream
+        from app.services.chat_service import ChatRequest
+
+        pipeline = MagicMock()
+        pipeline.query_stream = self._make_timeout_gen()
+
+        req = _stream_request(pipeline)
+        chat_req = ChatRequest(
+            question="Timeout testi?",
+            session_id="sess-timeout-2",
+            document_ids=[],
+        )
+
+        response = await chat_stream(chat_req, req)
+        events = await _collect_sse_events(response)
+        assert any(e.get("type") in ("done", "error") for e in events)
+
+    async def test_genel_runtime_error_error_event_gönderir(self):
+        """Beklenmedik RuntimeError → SSE error event, 500 değil."""
+        from app.api.routes.chat import chat_stream
+        from app.services.chat_service import ChatRequest
+
+        async def _crashing(*args, **kwargs):
+            yield "başlıyor"
+            raise RuntimeError("LLM API 503 döndü")
+
+        pipeline = MagicMock()
+        pipeline.query_stream = _crashing
+
+        req = _stream_request(pipeline)
+        chat_req = ChatRequest(
+            question="Soru var mı?",
+            session_id="sess-crash",
+            document_ids=[],
+        )
+
+        response = await chat_stream(chat_req, req)
+        events = await _collect_sse_events(response)
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert len(error_events) == 1
+
+
+# ── C. Redis Kesintisi Senaryoları ────────────────────────────────────────────
+
+class TestRedisDisconnectionDegradation:
+    """Redis kullanılamaz → API graceful degrade etmeli, çökmemeli."""
+
+    async def test_cache_get_hatasi_query_devam_eder(self, mock_pipeline):
+        """cache.get() ConnectionError fırlatırsa chat query yine de çalışmalı."""
+        from app.api.routes.chat import chat
+        from app.services.chat_service import ChatRequest
+
+        broken_cache = AsyncMock()
+        broken_cache.get = AsyncMock(side_effect=ConnectionError("Redis bağlantısı reddedildi"))
+
+        req = MagicMock()
+        req.app.state.semantic_cache = broken_cache
+        req.app.state.rag_pipeline = mock_pipeline
+
+        chat_req = ChatRequest(
+            question="Redis bozuldu mu?",
+            session_id="sess-redis-fail",
+            document_ids=["doc-001"],
+        )
+
+        result = await chat(chat_req, req)
+        assert result is not None
+        assert result.question == "Redis bozuldu mu?"
+
+    async def test_worker_startup_redis_ping_hatasi_exception_firlatir(self):
+        """startup() sırasında Redis ping başarısız olursa exception fırlatılmalı."""
+        ctx = {"redis": AsyncMock()}
+        ctx["redis"].ping = AsyncMock(side_effect=ConnectionError("Redis kullanılamıyor"))
+
+        with (
+            patch("app.workers.ingestion_worker.get_embedder", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.VectorStore") as mock_vs,
+            patch("app.workers.ingestion_worker.Reranker", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.create_llm_client", return_value=MagicMock()),
+            patch("app.workers.ingestion_worker.RAGPipeline", return_value=MagicMock()),
+        ):
+            mock_vs.return_value.setup = MagicMock()
+            with pytest.raises(ConnectionError):
+                await startup(ctx)
+
+    async def test_arq_redis_yoksa_upload_503_firlatir(self):
+        """app.state.arq_redis None ise upload → 503 döndürmeli."""
+        from app.api.routes.upload import upload_documents
+
+        def _dosya():
+            f = MagicMock()
+            f.filename = "test.pdf"
+            f.read = AsyncMock(return_value=b"%PDF-1.4 test")
+            return f
+
+        def _aiofiles_mock():
+            m = AsyncMock()
+            m.write = AsyncMock()
+            cm = AsyncMock()
+            cm.__aenter__ = AsyncMock(return_value=m)
+            cm.__aexit__ = AsyncMock(return_value=False)
+            return cm
+
+        req = MagicMock()
+        req.app.state.arq_redis = None
+
+        with patch("aiofiles.open", return_value=_aiofiles_mock()):
+            with pytest.raises((HTTPException, AttributeError)):
+                await upload_documents(req, files=[_dosya()], session_id="s")
+
+    async def test_streaming_redis_olmadan_calisir(self, mock_pipeline):
+        """Semantic cache Redis'e bağlanamasa bile SSE streaming çalışmalı."""
+        from app.api.routes.chat import chat_stream
+        from app.services.chat_service import ChatRequest
+
+        broken_cache = AsyncMock()
+        broken_cache.get = AsyncMock(side_effect=ConnectionError("Redis çevrimdışı"))
+
+        async def _simple_stream(*args, **kwargs):
+            yield "Redis"
+            yield " olmadan"
+            yield " çalışıyor."
+
+        mock_pipeline.query_stream = _simple_stream
+
+        req = MagicMock()
+        req.app.state.semantic_cache = broken_cache
+        req.app.state.rag_pipeline = mock_pipeline
+
+        chat_req = ChatRequest(
+            question="Redis olmadan çalışıyor mu?",
+            session_id="sess-no-redis",
+            document_ids=[],
+        )
+
+        response = await chat_stream(chat_req, req)
+        events = await _collect_sse_events(response)
+
+        assert any(e.get("type") in ("token", "error") for e in events)
+        assert events[-1]["type"] in ("done", "error")

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,0 +1,146 @@
+import { useState, useCallback, useRef } from 'react';
+import { useSSE } from './useSSE';
+import { getSessionId } from '../utils/session';
+import { SSE_EVENT_TYPES } from '../utils/constants';
+
+export interface SourceInfo {
+  document_id: string;
+  filename: string;
+  chunk_text: string;
+}
+
+export interface Message {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  sources?: SourceInfo[];
+  isStreaming?: boolean;
+}
+
+export interface UseChatReturn {
+  messages: Message[];
+  isStreaming: boolean;
+  error: string | null;
+  sendMessage: (question: string) => void;
+  clearMessages: () => void;
+}
+
+export function useChat(documentIds?: string[]): UseChatReturn {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { connect, disconnect } = useSSE();
+  const streamingMessageIdRef = useRef<string | null>(null);
+
+  const sendMessage = useCallback((question: string) => {
+    if (isStreaming) return;
+
+    const userMessage: Message = {
+      id: crypto.randomUUID?.() ?? Date.now().toString(),
+      role: 'user',
+      content: question,
+    };
+
+    const assistantMessageId = crypto.randomUUID?.() ?? (Date.now() + 1).toString();
+    const assistantMessage: Message = {
+      id: assistantMessageId,
+      role: 'assistant',
+      content: '',
+      isStreaming: true,
+    };
+
+    streamingMessageIdRef.current = assistantMessageId;
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setIsStreaming(true);
+    setError(null);
+
+    connect('/api/routes/chat/stream', {
+      method: 'POST',
+      body: {
+        question,
+        session_id: getSessionId(),
+        document_ids: documentIds ?? null,
+      },
+      onMessage: ({ data }) => {
+        const payload = data as { type: string; content?: string; documents?: SourceInfo[] };
+
+        if (payload.type === SSE_EVENT_TYPES.TOKEN && payload.content !== undefined) {
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === streamingMessageIdRef.current
+                ? { ...msg, content: msg.content + payload.content }
+                : msg
+            )
+          );
+        } else if (payload.type === SSE_EVENT_TYPES.SOURCES && payload.documents) {
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === streamingMessageIdRef.current
+                ? { ...msg, sources: payload.documents }
+                : msg
+            )
+          );
+        } else if (payload.type === SSE_EVENT_TYPES.DONE) {
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === streamingMessageIdRef.current
+                ? { ...msg, isStreaming: false }
+                : msg
+            )
+          );
+          streamingMessageIdRef.current = null;
+          setIsStreaming(false);
+          disconnect();
+        } else if (payload.type === SSE_EVENT_TYPES.ERROR) {
+          const errMsg = (payload as { type: string; message?: string }).message ?? 'Bilinmeyen hata';
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === streamingMessageIdRef.current
+                ? { ...msg, isStreaming: false, content: msg.content || errMsg }
+                : msg
+            )
+          );
+          streamingMessageIdRef.current = null;
+          setIsStreaming(false);
+          setError(errMsg);
+          disconnect();
+        }
+      },
+      onError: (err) => {
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === streamingMessageIdRef.current
+              ? { ...msg, isStreaming: false }
+              : msg
+          )
+        );
+        streamingMessageIdRef.current = null;
+        setIsStreaming(false);
+        setError(err.message);
+      },
+      onClose: () => {
+        if (streamingMessageIdRef.current) {
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === streamingMessageIdRef.current
+                ? { ...msg, isStreaming: false }
+                : msg
+            )
+          );
+          streamingMessageIdRef.current = null;
+          setIsStreaming(false);
+        }
+      },
+    });
+  }, [isStreaming, documentIds, connect, disconnect]);
+
+  const clearMessages = useCallback(() => {
+    disconnect();
+    streamingMessageIdRef.current = null;
+    setMessages([]);
+    setIsStreaming(false);
+    setError(null);
+  }, [disconnect]);
+
+  return { messages, isStreaming, error, sendMessage, clearMessages };
+}

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,0 +1,146 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+export interface SSEEvent {
+  type: string;
+  data: unknown;
+}
+
+export interface SSEOptions {
+  method?: 'GET' | 'POST';
+  body?: unknown;
+  onMessage: (event: SSEEvent) => void;
+  onError?: (error: Error) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+  maxRetries?: number;
+}
+
+export interface SSEState {
+  isConnected: boolean;
+  error: Error | null;
+  connect: (url: string, options: SSEOptions) => void;
+  disconnect: () => void;
+}
+
+export function useSSE(): SSEState {
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const disconnect = useCallback(() => {
+    if (retryTimeoutRef.current) {
+      clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    setIsConnected(false);
+  }, []);
+
+  const connect = useCallback((url: string, options: SSEOptions) => {
+    const { method = 'GET', body, onMessage, onError, onOpen, onClose, maxRetries = 3 } = options;
+
+    disconnect();
+    retryCountRef.current = 0;
+
+    const attemptConnect = async () => {
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      try {
+        const fetchOptions: RequestInit = {
+          method,
+          signal: controller.signal,
+          headers: {
+            Accept: 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            ...(body ? { 'Content-Type': 'application/json' } : {}),
+          },
+          ...(body ? { body: JSON.stringify(body) } : {}),
+        };
+
+        const response = await fetch(url, fetchOptions);
+
+        if (!response.ok) {
+          throw new Error(`SSE bağlantı hatası: ${response.status} ${response.statusText}`);
+        }
+
+        if (!response.body) {
+          throw new Error('Response body boş');
+        }
+
+        setIsConnected(true);
+        setError(null);
+        retryCountRef.current = 0;
+        onOpen?.();
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() ?? '';
+
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed || trimmed.startsWith(':')) continue;
+
+              if (trimmed.startsWith('data:')) {
+                const rawData = trimmed.slice(5).trim();
+                try {
+                  const parsed = JSON.parse(rawData);
+                  onMessage({ type: parsed.type ?? 'message', data: parsed });
+                } catch {
+                  onMessage({ type: 'message', data: rawData });
+                }
+              }
+            }
+          }
+        } finally {
+          reader.cancel();
+        }
+
+        setIsConnected(false);
+        onClose?.();
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') {
+          return;
+        }
+
+        const connError = err instanceof Error ? err : new Error(String(err));
+        setIsConnected(false);
+
+        if (retryCountRef.current < maxRetries) {
+          const delay = 60 * Math.pow(2, retryCountRef.current);
+          retryCountRef.current++;
+          retryTimeoutRef.current = setTimeout(attemptConnect, delay);
+        } else {
+          setError(connError);
+          onError?.(connError);
+          onClose?.();
+        }
+      }
+    };
+
+    attemptConnect();
+  }, [disconnect]);
+
+  useEffect(() => {
+    return () => {
+      disconnect();
+    };
+  }, [disconnect]);
+
+  return { isConnected, error, connect, disconnect };
+}

--- a/frontend/src/hooks/useUpload.ts
+++ b/frontend/src/hooks/useUpload.ts
@@ -1,0 +1,170 @@
+import { useState, useCallback, useRef } from 'react';
+import axios from 'axios';
+import { validateFile } from '../utils/validators';
+import { DOC_STATUS, UPLOAD_POLL_INTERVAL_MS } from '../utils/constants';
+
+export type UploadStatus = 'idle' | 'uploading' | 'processing' | 'done' | 'error';
+
+export interface UploadedFile {
+  document_id: string;
+  filename: string;
+  status: UploadStatus;
+  error?: string;
+}
+
+interface DocumentUploadResponse {
+  document_id: string;
+  filename: string;
+  status: string;
+  message: string;
+}
+
+interface DocumentListItem {
+  document_id: string;
+  filename: string;
+  status: string;
+}
+
+interface DocumentListResponse {
+  documents: DocumentListItem[];
+  total: number;
+}
+
+export interface UseUploadReturn {
+  uploads: UploadedFile[];
+  isUploading: boolean;
+  uploadFiles: (files: File[]) => Promise<void>;
+  removeUpload: (documentId: string) => void;
+  clearUploads: () => void;
+}
+
+export function useUpload(): UseUploadReturn {
+  const [uploads, setUploads] = useState<UploadedFile[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const pollingIntervalsRef = useRef<Map<string, ReturnType<typeof setInterval>>>(new Map());
+
+  const stopPolling = useCallback((documentId: string) => {
+    const interval = pollingIntervalsRef.current.get(documentId);
+    if (interval) {
+      clearInterval(interval);
+      pollingIntervalsRef.current.delete(documentId);
+    }
+  }, []);
+
+  const startPolling = useCallback((documentId: string) => {
+    // TODO(Faz 3): /api/tasks/{job_id}/progress SSE endpoint hazır olduğunda
+    // polling yerine SSE stream kullan
+
+    const interval = setInterval(async () => {
+      try {
+        const response = await axios.get<DocumentListResponse>('/api/routes/documents');
+        const doc = response.data.documents.find((d) => d.document_id === documentId);
+
+        if (!doc) return;
+
+        if (doc.status === DOC_STATUS.COMPLETED) {
+          setUploads((prev) =>
+            prev.map((u) =>
+              u.document_id === documentId ? { ...u, status: 'done' } : u
+            )
+          );
+          stopPolling(documentId);
+        } else if (doc.status === DOC_STATUS.FAILED) {
+          setUploads((prev) =>
+            prev.map((u) =>
+              u.document_id === documentId
+                ? { ...u, status: 'error', error: 'Belge işleme başarısız' }
+                : u
+            )
+          );
+          stopPolling(documentId);
+        }
+      } catch {
+        // Polling hatalarını sessizce geç, bir sonraki interval'de tekrar dene
+      }
+    }, UPLOAD_POLL_INTERVAL_MS);
+
+    pollingIntervalsRef.current.set(documentId, interval);
+  }, [stopPolling]);
+
+  const uploadFiles = useCallback(async (files: File[]) => {
+    const validFiles: File[] = [];
+    const invalidEntries: UploadedFile[] = [];
+
+    for (const file of files) {
+      const result = validateFile(file);
+      if (result.valid) {
+        validFiles.push(file);
+      } else {
+        invalidEntries.push({
+          document_id: crypto.randomUUID?.() ?? Date.now().toString(),
+          filename: file.name,
+          status: 'error',
+          error: result.error,
+        });
+      }
+    }
+
+    if (invalidEntries.length > 0) {
+      setUploads((prev) => [...prev, ...invalidEntries]);
+    }
+
+    if (validFiles.length === 0) return;
+
+    setIsUploading(true);
+
+    const formData = new FormData();
+    for (const file of validFiles) {
+      formData.append('files', file);
+    }
+
+    try {
+      const response = await axios.post<DocumentUploadResponse[]>(
+        '/api/routes/upload',
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } }
+      );
+
+      const uploadedEntries: UploadedFile[] = response.data.map((item) => ({
+        document_id: item.document_id,
+        filename: item.filename,
+        status: 'processing' as UploadStatus,
+      }));
+
+      setUploads((prev) => [...prev, ...uploadedEntries]);
+
+      for (const entry of uploadedEntries) {
+        startPolling(entry.document_id);
+      }
+    } catch (err) {
+      const message =
+        axios.isAxiosError(err) && err.response?.data?.detail
+          ? String(err.response.data.detail)
+          : 'Yükleme başarısız';
+
+      const errorEntries: UploadedFile[] = validFiles.map((file) => ({
+        document_id: crypto.randomUUID?.() ?? Date.now().toString(),
+        filename: file.name,
+        status: 'error' as UploadStatus,
+        error: message,
+      }));
+
+      setUploads((prev) => [...prev, ...errorEntries]);
+    } finally {
+      setIsUploading(false);
+    }
+  }, [startPolling]);
+
+  const removeUpload = useCallback((documentId: string) => {
+    stopPolling(documentId);
+    setUploads((prev) => prev.filter((u) => u.document_id !== documentId));
+  }, [stopPolling]);
+
+  const clearUploads = useCallback(() => {
+    pollingIntervalsRef.current.forEach((_, id) => stopPolling(id));
+    setUploads([]);
+    setIsUploading(false);
+  }, [stopPolling]);
+
+  return { uploads, isUploading, uploadFiles, removeUpload, clearUploads };
+}


### PR DESCRIPTION
## Summary

Bu PR, daha önce placeholder/pass bırakan tüm kritik akışları gerçek implementasyonlara bağlar:

- **Chat endpointleri** artık gerçek `RAGPipeline.query()` / `query_stream()` çağrıları yapar;
  SSE akışı `token | sources | done | error` event tiplerine ayrılmıştır.
- **Upload endpointi** dosya kaydettikten sonra ARQ iş kuyruğuna (`arq_redis.enqueue_job`) görev
  iletir ve yanıtta `job_id` döner.
- **Ingestion worker** artık dosyayı gerçekten işler: RAG pipeline'ı başlatır, Redis üzerinden
  aşama bazlı ilerleme (`parsing → embedding → indexing → done/error`) yazar.
- **`/api/routes/tasks/{job_id}`** ve **`/api/routes/tasks/{job_id}/progress`** endpoint'leri
  eklendi; ilki ARQ iş durumunu döner, ikincisi SSE üzerinden canlı ilerleme akışı sağlar.
- **`VectorStore.list_documents()`** eklendi: offset-tabanlı scroll ile session'a ait tüm
  unique dokümanları ve chunk sayılarını getirir.
- **Documents endpointleri** (`GET /documents`, `DELETE /documents/{id}`) artık gerçek Qdrant
  sorgularını kullanır; `session_id` parametresi desteklenir.
- **`app/models/task.py`** oluşturuldu: `TaskStatus`, `TaskResponse`, `TaskProgressEvent`
  Pydantic modelleri.
- **Frontend hooks** (`useChat`, `useSSE`, `useUpload`) sıfırdan yazıldı: SSE bağlantı yönetimi,
  token-by-token mesaj birleştirme, kaynak gösterimi ve upload ilerleme takibi.
- **`main.py` lifespan**: ARQ Redis havuzu ve RAG pipeline uygulama başlangıcında initialize
  edilir, kapanışta temizlenir.
- Mevcut unit testler güncellendi; yeni integration ve error-scenario testleri eklendi.

## Test plan

- [ ] `POST /api/routes/upload` → `job_id` döndüğünü doğrula
- [ ] `GET /api/routes/tasks/{job_id}` → `pending / running / completed` durumlarını doğrula
- [ ] `GET /api/routes/tasks/{job_id}/progress` SSE akışında `progress → done` eventlerini doğrula
- [ ] `POST /api/routes/chat/stream` SSE akışında `token`, `sources`, `done` eventlerini doğrula
- [ ] `GET /api/routes/documents?session_id=X` gerçek doküman listesini döndürdüğünü doğrula
- [ ] `DELETE /api/routes/documents/{id}` Qdrant'tan sildiğini doğrula
- [ ] Worker hata durumunda Redis'e `event: error` yazdığını doğrula
- [ ] `pytest backend/tests/` tüm testlerin geçtiğini doğrula
